### PR TITLE
Display debug.log in reverse order in web-ui

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -122,12 +122,15 @@ export function App(): ReactElement {
     logContentRef.current = '';
     setLogContent('');
 
+    const isDebug = logKind === 'debug';
+
     const replaceLog = (nextContent: string): void => {
       if (closed || nextContent === logContentRef.current) {
         return;
       }
       logContentRef.current = nextContent;
-      startTransition(() => setLogContent(nextContent));
+      const display = isDebug ? reverseLines(nextContent) : nextContent;
+      startTransition(() => setLogContent(display));
     };
 
     const refreshLog = async (): Promise<void> => {
@@ -179,7 +182,12 @@ export function App(): ReactElement {
       }
 
       logContentRef.current = nextContent;
-      startTransition(() => setLogContent(nextContent));
+      if (isDebug) {
+        const reversed = reverseLines(chunk);
+        startTransition(() => setLogContent((prev) => reversed + (prev ? '\n' + prev : '')));
+      } else {
+        startTransition(() => setLogContent(nextContent));
+      }
     };
 
     return () => {
@@ -712,11 +720,8 @@ function renderViewerBody(
   setShowRawFinalResponse: (next: boolean) => void,
 ): ReactElement {
   if (isLiveLogTab(viewerTab)) {
-    const displayContent = viewerTab === 'debug' && logContent
-      ? reverseLines(logContent)
-      : logContent;
     return (
-      <pre>{displayContent || (viewerTab === 'debug' ? 'Waiting for debug output...' : 'Waiting for output...')}</pre>
+      <pre>{logContent || (viewerTab === 'debug' ? 'Waiting for debug output...' : 'Waiting for output...')}</pre>
     );
   }
 


### PR DESCRIPTION
## Summary
- Reverse line order of the debug.log viewer so newest entries appear at the top
- Users no longer need to scroll to the bottom of long debug logs to see recent output
- Run log remains in chronological order (append-style streaming)

## Test plan
- [ ] Start a job and switch to the debug.log tab
- [ ] Verify newest log lines appear at the top
- [ ] Verify the run.log tab still streams in chronological order
- [ ] Verify the "Waiting for debug output..." placeholder still shows when empty