### PR TITLE
Fix GH_HOST missing for enterprise GitHub hosts in RepoBroker

### DIFF
--- a/src/server/repo-broker.ts
+++ b/src/server/repo-broker.ts
@@ -46,6 +46,19 @@ export class RepoBroker {
     return env ? { env } : {};
   }
 
+  /** Build env for gh CLI commands: proxy + GH_REPO + GH_HOST (for enterprise hosts). */
+  private ghEnv(record: JobRecord): NodeJS.ProcessEnv {
+    const env = this.proxyEnv(record);
+    const result: NodeJS.ProcessEnv = {
+      ...(env ?? process.env),
+      GH_REPO: repoSlugFromUrl(record.spec.repoUrl),
+    };
+    if (record.spec.githubHost !== 'github.com') {
+      result.GH_HOST = record.spec.githubHost;
+    }
+    return result;
+  }
+
   async runGitRead(record: JobRecord, args: string[]): Promise<CommandResult> {
     await validateGitReadArgs(this.execute, record, args);
     return await this.execute('git', [ '-C', record.workspacePath, ...args ], this.proxyOpts(record));
@@ -53,13 +66,9 @@ export class RepoBroker {
 
   async runGhRead(record: JobRecord, args: string[]): Promise<CommandResult> {
     validateGhReadArgs(args);
-    const env = this.proxyEnv(record);
     return await this.execute('gh', [ ...args ], {
       cwd: record.workspacePath,
-      env: {
-        ...(env ?? process.env),
-        GH_REPO: repoSlugFromUrl(record.spec.repoUrl),
-      },
+      env: this.ghEnv(record),
     });
   }
 
@@ -114,13 +123,9 @@ export class RepoBroker {
     if (options.base) {
       args.push('--base', options.base);
     }
-    const env = this.proxyEnv(record);
     return await this.execute('gh', args, {
       cwd: record.workspacePath,
-      env: {
-        ...(env ?? process.env),
-        GH_REPO: repoSlugFromUrl(record.spec.repoUrl),
-      },
+      env: this.ghEnv(record),
     });
   }
 
@@ -131,13 +136,9 @@ export class RepoBroker {
     if (!options.pr.trim() || !options.body.trim()) {
       throw new Error('Missing PR comment arguments');
     }
-    const env = this.proxyEnv(record);
     return await this.execute('gh', [ 'pr', 'comment', options.pr, '--body', options.body ], {
       cwd: record.workspacePath,
-      env: {
-        ...(env ?? process.env),
-        GH_REPO: repoSlugFromUrl(record.spec.repoUrl),
-      },
+      env: this.ghEnv(record),
     });
   }
 }

--- a/src/tests/repo-broker.test.ts
+++ b/src/tests/repo-broker.test.ts
@@ -285,6 +285,56 @@ test('repo broker sets HTTPS_PROXY for enterprise host — commentPr', async () 
   assert.equal(capturedEnvs[0]?.HTTPS_PROXY, 'socks5://127.0.0.1:8080');
 });
 
+test('repo broker sets GH_HOST for enterprise host — runGhRead', async () => {
+  const capturedEnvs: Array<NodeJS.ProcessEnv | undefined> = [];
+  const broker = new RepoBroker(testConfig, async (_command, _args, options = {}) => {
+    capturedEnvs.push(options.env);
+    return { stdout: '', stderr: '', exitCode: 0 };
+  });
+
+  await broker.runGhRead(createEnterpriseJobRecord(), [ 'repo', 'view' ]);
+  assert.equal(capturedEnvs[0]?.GH_HOST, 'github.a8c.com');
+});
+
+test('repo broker sets GH_HOST for enterprise host — openPr', async () => {
+  const capturedEnvs: Array<NodeJS.ProcessEnv | undefined> = [];
+  const broker = new RepoBroker(testConfig, async (_command, _args, options = {}) => {
+    capturedEnvs.push(options.env);
+    return { stdout: '', stderr: '', exitCode: 0 };
+  });
+
+  await broker.openPr(createEnterpriseJobRecord(), { title: 'Test PR' });
+  assert.equal(capturedEnvs[0]?.GH_HOST, 'github.a8c.com');
+});
+
+test('repo broker sets GH_HOST for enterprise host — commentPr', async () => {
+  const capturedEnvs: Array<NodeJS.ProcessEnv | undefined> = [];
+  const broker = new RepoBroker(testConfig, async (_command, _args, options = {}) => {
+    capturedEnvs.push(options.env);
+    return { stdout: '', stderr: '', exitCode: 0 };
+  });
+
+  await broker.commentPr(createEnterpriseJobRecord(), { pr: '42', body: 'LGTM' });
+  assert.equal(capturedEnvs[0]?.GH_HOST, 'github.a8c.com');
+});
+
+test('repo broker does not set GH_HOST for github.com hosts', async () => {
+  const capturedEnvs: Array<NodeJS.ProcessEnv | undefined> = [];
+  const broker = new RepoBroker(testConfig, async (_command, _args, options = {}) => {
+    capturedEnvs.push(options.env);
+    return { stdout: '', stderr: '', exitCode: 0 };
+  });
+
+  await broker.runGhRead(createJobRecord(), [ 'repo', 'view' ]);
+  assert.equal(capturedEnvs[0]?.GH_HOST, undefined);
+
+  await broker.openPr(createJobRecord(), { title: 'Test PR' });
+  assert.equal(capturedEnvs[1]?.GH_HOST, undefined);
+
+  await broker.commentPr(createJobRecord(), { pr: '42', body: 'LGTM' });
+  assert.equal(capturedEnvs[2]?.GH_HOST, undefined);
+});
+
 test('repo broker does not set HTTPS_PROXY for github.com hosts', async () => {
   const capturedEnvs: Array<NodeJS.ProcessEnv | undefined> = [];
   const broker = new RepoBroker(testConfig, async (_command, _args, options = {}) => {


### PR DESCRIPTION
## Summary

- RepoBroker set `GH_REPO` (e.g. `Automattic/biff`) without `GH_HOST`, so `gh` CLI defaulted to `github.com` for all operations. Enterprise repos on `github.a8c.com` failed with "GraphQL: cannot resolve" / "no access" errors on PR creation, reads, and comments.
- Added a `ghEnv()` helper that conditionally sets `GH_HOST` for non-`github.com` hosts, consolidating the duplicated env construction across `runGhRead`, `openPr`, and `commentPr`.
- Also identified that `AGENT_RUNNER_GITHUB_PROXY_URL` was missing from `.env` (secondary issue, fix applied locally).

## Test plan

- [x] All 104 existing tests pass
- [x] 4 new tests verify `GH_HOST` is set for enterprise hosts and absent for `github.com`
- [ ] Run an agent-runner job against a `github.a8c.com` repo and confirm PR creation succeeds